### PR TITLE
Accepting commands with arguments

### DIFF
--- a/gid_smart_wizard.tcl
+++ b/gid_smart_wizard.tcl
@@ -392,7 +392,7 @@ proc smart_wizard::AutoStep {win stepid} {
                     grid [set $lab] [set $ent] -sticky ew
                 }
                 button {
-                    set but$order [ttk::button $fr.b$order -text $txt -command [list $value]]
+                    set but$order [ttk::button $fr.b$order -text $txt -command $value]
                     set button "but$order"
                     grid [expr $$button] -columnspan 3 -sticky ew
                 }


### PR DESCRIPTION
value is an string defined inside xml, we do not need to add [list] this is going to destroy any command with argument